### PR TITLE
VS-637 Upgrades @babel/runtime@7.12.5

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,7 +2,7 @@
   "presets": [
     ["env", {
       "targets": {
-        "node": 7.0
+        "node": 12.14
       },
       "useBuiltIns": true
     }]

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,28 +8,6 @@ var _promise = require('babel-runtime/core-js/promise');
 
 var _promise2 = _interopRequireDefault(_promise);
 
-var _asyncToGenerator2 = require('babel-runtime/helpers/asyncToGenerator');
-
-var _asyncToGenerator3 = _interopRequireDefault(_asyncToGenerator2);
-
-let _exec = (() => {
-  var _ref = (0, _asyncToGenerator3.default)(function* (cmd, options = { timeout: 1000 }) {
-    return new _promise2.default(function (resolve, reject) {
-      _child_process2.default.exec(cmd, options, function (err, stdout) {
-        if (err) {
-          reject(err);
-        } else {
-          resolve(stdout.trim());
-        }
-      });
-    });
-  });
-
-  return function _exec(_x) {
-    return _ref.apply(this, arguments);
-  };
-})();
-
 var _child_process = require('child_process');
 
 var _child_process2 = _interopRequireDefault(_child_process);
@@ -42,6 +20,18 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 // TODO: Consider using nodegit instead
 const GIT_PREFIX = 'git';
+
+async function _exec(cmd, options = { timeout: 1000 }) {
+  return new _promise2.default((resolve, reject) => {
+    _child_process2.default.exec(cmd, options, (err, stdout) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(stdout.trim());
+      }
+    });
+  });
+}
 
 class ServerlessGitVariables {
   constructor(serverless, options) {
@@ -64,91 +54,77 @@ class ServerlessGitVariables {
     };
   }
 
-  _getValue(variable) {
-    var _this = this;
+  async _getValue(variable) {
+    if (this.resolvedValues[variable]) {
+      return _promise2.default.resolve(this.resolvedValues[variable]);
+    }
 
-    return (0, _asyncToGenerator3.default)(function* () {
-      if (_this.resolvedValues[variable]) {
-        return _promise2.default.resolve(_this.resolvedValues[variable]);
-      }
-
-      return _this._getValueFromGit(variable);
-    })();
+    return this._getValueFromGit(variable);
   }
 
-  _getValueFromGit(variable) {
-    var _this2 = this;
+  async _getValueFromGit(variable) {
+    let value = null;
+    switch (variable) {
+      case 'describe':
+        value = await _exec('git describe --always');
+        break;
+      case 'describeLight':
+        value = await _exec('git describe --always --tags');
+        break;
+      case 'sha1':
+        value = await _exec('git rev-parse --short HEAD');
+        break;
+      case 'commit':
+        value = await _exec('git rev-parse HEAD');
+        break;
+      case 'branch':
+        value = await _exec('git rev-parse --abbrev-ref HEAD');
+        break;
+      case 'message':
+        value = await _exec('git log -1 --pretty=%B');
+        break;
+      case 'isDirty':
+        value = (await _exec('git diff --stat')) !== '';
+        break;
+      case 'repository':
+        const pathName = await _exec('git rev-parse --show-toplevel');
+        value = _path2.default.basename(pathName);
+        break;
+      default:
+        throw new Error(`Git variable ${variable} is unknown. Candidates are 'describe', 'describeLight', 'sha1', 'commit', 'branch', 'message', 'repository'`);
+    }
 
-    return (0, _asyncToGenerator3.default)(function* () {
-      let value = null;
-      switch (variable) {
-        case 'describe':
-          value = yield _exec('git describe --always');
-          break;
-        case 'describeLight':
-          value = yield _exec('git describe --always --tags');
-          break;
-        case 'sha1':
-          value = yield _exec('git rev-parse --short HEAD');
-          break;
-        case 'commit':
-          value = yield _exec('git rev-parse HEAD');
-          break;
-        case 'branch':
-          value = yield _exec('git rev-parse --abbrev-ref HEAD');
-          break;
-        case 'message':
-          value = yield _exec('git log -1 --pretty=%B');
-          break;
-        case 'isDirty':
-          const writeTree = yield _exec('git write-tree');
-          const changes = yield _exec(`git diff-index ${writeTree} --`);
-          value = `${changes.length > 0}`;
-          break;
-        case 'repository':
-          const pathName = yield _exec('git rev-parse --show-toplevel');
-          value = _path2.default.basename(pathName);
-          break;
-        default:
-          throw new Error(`Git variable ${variable} is unknown. Candidates are 'describe', 'describeLight', 'sha1', 'commit', 'branch', 'message', 'repository'`);
-      }
+    // TODO: Figure out why if I don't log, the deasync promise
+    // never resolves. Catching it in the debugger or logging
+    // causes it to work fine.
+    process.stdout.write('');
 
-      // TODO: Figure out why if I don't log, the deasync promise
-      // never resolves. Catching it in the debugger or logging
-      // causes it to work fine.
-      process.stdout.write('');
-
-      // Cache before returning
-      _this2.resolvedValues[variable] = value;
-      return value;
-    })();
+    // Cache before returning
+    this.resolvedValues[variable] = value;
+    return value;
   }
 
-  exportGitVariables() {
-    var _this3 = this;
+  async exportGitVariables() {
+    const exportGitVariables = this.serverless.service.custom && this.serverless.service.custom.exportGitVariables;
+    if (exportGitVariables === false) {
+      return;
+    }
 
-    return (0, _asyncToGenerator3.default)(function* () {
-      const exportGitVariables = _this3.serverless.service.custom && _this3.serverless.service.custom.exportGitVariables;
-      if (exportGitVariables === false) {
-        return;
-      }
+    const sha1 = await this._getValue('sha1');
+    const commit = await this._getValue('commit');
+    const branch = await this._getValue('branch');
+    const isDirty = await this._getValue('isDirty');
+    const repository = await this._getValue('repository');
 
-      const sha1 = yield _this3._getValue('sha1');
-      const commit = yield _this3._getValue('commit');
-      const branch = yield _this3._getValue('branch');
-      const isDirty = yield _this3._getValue('isDirty');
-      const repository = yield _this3._getValue('repository');
+    for (const functionName of this.serverless.service.getAllFunctions()) {
+      const func = this.serverless.service.getFunction(functionName);
 
-      for (const functionName of _this3.serverless.service.getAllFunctions()) {
-        const func = _this3.serverless.service.getFunction(functionName);
-
-        _this3.exportGitVariable(func, 'GIT_COMMIT_SHORT', sha1);
-        _this3.exportGitVariable(func, 'GIT_COMMIT_LONG', commit);
-        _this3.exportGitVariable(func, 'GIT_BRANCH', branch);
-        _this3.exportGitVariable(func, 'GIT_IS_DIRTY', isDirty);
-        _this3.exportGitVariable(func, 'GIT_REPOSITORY', repository);
-      }
-    })();
+      this.exportGitVariable(func, 'GIT_COMMIT_SHORT', sha1);
+      this.exportGitVariable(func, 'GIT_COMMIT_LONG', commit);
+      this.exportGitVariable(func, 'GIT_BRANCH', branch);
+      this.exportGitVariable(func, 'GIT_IS_DIRTY', isDirty);
+      this.exportGitVariable(func, 'GIT_REPOSITORY', repository);
+    }
   }
 
   exportGitVariable(func, variableName, gitValue) {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "ci:coverage": "nyc report --reporter=text-lcov | coveralls"
   },
   "dependencies": {
-    "babel-runtime": "6.23.0"
+    "@babel/runtime": "^7.12.5"
   },
   "devDependencies": {
     "ava": "0.20.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -38,6 +38,13 @@
     imurmurhash "^0.1.4"
     slide "^1.1.5"
 
+"@babel/runtime@^7.12.5":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
+  integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@concordance/react@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@concordance/react/-/react-1.0.0.tgz#fcf3cad020e5121bfd1c61d05bc3516aac25f734"
@@ -889,7 +896,7 @@ babel-register@6.18.0, babel-register@^6.18.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.2"
 
-babel-runtime@6.23.0, babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtime@^6.20.0, babel-runtime@^6.22.0, babel-runtime@^6.9.0:
+babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtime@^6.20.0, babel-runtime@^6.22.0, babel-runtime@^6.9.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.23.0.tgz#0a9489f144de70efb3ce4300accdb329e2fc543b"
   dependencies:
@@ -3759,6 +3766,11 @@ regenerate@^1.2.1:
 regenerator-runtime@^0.10.0:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.3.tgz#8c4367a904b51ea62a908ac310bf99ff90a82a3e"
+
+regenerator-runtime@^0.13.4:
+  version "0.13.7"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz#cac2dacc8a1ea675feaabaeb8ae833898ae46f55"
+  integrity sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==
 
 regenerator-transform@0.9.11:
   version "0.9.11"


### PR DESCRIPTION
This came up as an issue once we upgraded _another_ dependency for https://github.com/xoeye/vision-stratus/pull/921.  Somehow `babel-runtime@6.23.0` was not being installed.